### PR TITLE
Remove util.DriverName constant completely

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -115,7 +115,7 @@ const (
 	// KubernetesTagKeyPrefix is the prefix of the key value that is reserved for Kubernetes.
 	KubernetesTagKeyPrefix = "kubernetes.io"
 	// AwsEbsDriverTagKey is the tag to identify if a volume/snapshot is managed by ebs csi driver.
-	AwsEbsDriverTagKey = util.DriverName + "/cluster"
+	AwsEbsDriverTagKey = "ebs.csi.aws.com/cluster"
 )
 
 // Batcher.

--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -18,8 +18,6 @@ package driver
 
 import (
 	"time"
-
-	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/util"
 )
 
 // constants of keys in PublishContext.
@@ -185,7 +183,7 @@ const (
 // constants for node k8s API use.
 const (
 	// AgentNotReadyNodeTaintKey contains the key of taints to be removed on driver startup.
-	AgentNotReadyNodeTaintKey = util.DriverName + "/agent-not-ready"
+	AgentNotReadyNodeTaintKey = "ebs.csi.aws.com/agent-not-ready"
 )
 
 type fileSystemConfig struct {

--- a/pkg/driver/identity.go
+++ b/pkg/driver/identity.go
@@ -20,14 +20,13 @@ import (
 	"context"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/util"
 	"k8s.io/klog/v2"
 )
 
 func (d *Driver) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
 	klog.V(6).InfoS("GetPluginInfo: called", "args", req)
 	resp := &csi.GetPluginInfoResponse{
-		Name:          util.DriverName,
+		Name:          DriverName,
 		VendorVersion: driverVersion,
 	}
 

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -1025,7 +1025,7 @@ func checkAllocatable(ctx context.Context, clientset kubernetes.Interface, nodeN
 	}
 
 	for _, driver := range csiNode.Spec.Drivers {
-		if driver.Name == util.DriverName {
+		if driver.Name == DriverName {
 			if driver.Allocatable != nil && driver.Allocatable.Count != nil {
 				klog.InfoS("CSINode Allocatable value is set", "nodeName", nodeName, "count", *driver.Allocatable.Count)
 				return nil

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -33,10 +33,6 @@ import (
 )
 
 const (
-	// DriverName is the domain for all EBS CSI Driver related components.
-	// In util package to avoid cyclic dependency conflicts.
-	DriverName = "ebs.csi.aws.com"
-
 	GiB              = int64(1024 * 1024 * 1024)
 	DefaultBlockSize = 4096
 )


### PR DESCRIPTION
#### What type of PR is this?

Remove util.DriverName from constant definition, and use DriverName variable to override driverName configuration.

I have skipped modifying AgentNotReadyNodeTaintKey and AwsEbsDriverTagKey constants but it may seems work:
- AwsEbsDriverTagKey is only used as tag in AWS resources. Since we don't use multiple ebs drivers in the same AWS account, CSI driver don't confuse them.
- AgentNotReadyNodeTaintKey is only used as node taint in Kubernetes Node object. Since we don't use multiple ebs drivers in the same node, CSI driver don't confuse them.